### PR TITLE
New research papers and code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,12 @@ Single-Modal Deep Hashing Methods
     Yue Cao, Mingsheng Long, Bin Liu, Jiamin Wang.
 [CVPR 2018] Deep Cauchy Hashing for Hamming Space Retrieval [`paper <http://ise.thss.tsinghua.edu.cn/~mlong/doc/deep-cauchy-hashing-cvpr18.pdf>`_] [`code <https://github.com/thulab/DeepHash>`_]
     Yue Cao, Mingsheng Long, Bin Liu, Jianmin Wang.
+[CVPR 2018] Hashing as Tie-Aware Learning to Rank [`paper <http://openaccess.thecvf.com/content_cvpr_2018/html/He_Hashing_as_Tie-Aware_CVPR_2018_paper.html>`_] [`code <https://github.com/kunhe/TALR>`_]
+    Kun He, Fatih Cakir, Sarah Adel Bargal, Stan Sclaroff. 
+[EECV 2018] Hashing with Binary Matrix Pursuit [`paper <https://arxiv.org/abs/1808.01990>`_] [`code <https://github.com/fcakir/hbmp>`_]
+    Fatih Cakir, Kun He, Stan Sclaroff. 
+[TPAMI 2019] Hashing with Mutual Information [`paper <http://arxiv.org/abs/1803.00974>`_] [`code <https://github.com/fcakir/deep-mihash/>`_]
+    Fatih Cakir*, Kun He*, Sarah Adel Bargal, Stan Sclaroff (equal contrib.). 
 
 Cross-Modal Deep Hashing Methods
 -------------------


### PR DESCRIPTION
Includes the following recently published papers:
1. Hashing as Tie-Aware Learning to Rank
Kun He, Fatih Cakir, Sarah Adel Bargal, and Stan Sclaroff
CVPR 2018

2. Hashing with Binary Matrix Pursuit
Fatih Cakir, Kun He, and Stan Sclaroff
ECCV 2018

3. Hashing with Mutual Information
Fatih Cakir*, Kun He*, Sarah Adel Bargal and Stan Sclaroff
TPAMI 2019 (to appear)
(eq. contrib.)
